### PR TITLE
Remove ImmutableJS dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "sinon-chai": "~2.8.0"
   },
   "dependencies": {
-    "immutable": "~3.7.4"
+    "lodash": "~3.10.1"
   }
 }

--- a/src/ParameterCollection.js
+++ b/src/ParameterCollection.js
@@ -1,16 +1,17 @@
 'use strict';
 
-var List = require('immutable').List;
+var each = require('lodash/collection/each');
+var find = require('lodash/collection/find');
 var Parameter = require('./Parameter');
 
 /**
- * @param {Array.<Parameter>} parameters
+ * @param {Array<Parameter>} parameters
  * @constructor
  */
 var ParameterCollection = function ParameterCollection(parameters) {
-    this.parameterList = new List(parameters || []);
+    this.parameters = parameters || [];
 
-    this.parameterList.forEach(function (parameter, key) {
+    each(this.parameters, function (parameter, key) {
         if (!(parameter instanceof Parameter)) {
             throw new Error('Wrong parameter type at position: "' + key + '".');
         }
@@ -22,7 +23,7 @@ var ParameterCollection = function ParameterCollection(parameters) {
  * @return {Parameter|undefined}
  */
 ParameterCollection.prototype.getParameter = function (name) {
-    return this.parameterList.find(function (parameter) {
+    return find(this.parameters, function (parameter) {
         return (name === parameter.getName());
     });
 };

--- a/src/ServiceArgumentCollection.js
+++ b/src/ServiceArgumentCollection.js
@@ -1,16 +1,17 @@
 'use strict';
 
-var List = require('immutable').List;
+var each = require('lodash/collection/each');
+var filter = require('lodash/collection/filter');
 var ServiceArgument = require('./ServiceArgument');
 
 /**
- * @param {Array.<ServiceArgument>} serviceArguments
+ * @param {Array<ServiceArgument>} serviceArguments
  * @constructor
  */
 var ServiceArgumentCollection = function ServiceArgumentCollection(serviceArguments) {
-    this.serviceArgumentList = new List(serviceArguments || []);
+    this.serviceArguments = serviceArguments || [];
 
-    this.serviceArgumentList.map(function (argument, index) {
+    each(this.serviceArguments, function (argument, index) {
         if (!(argument instanceof ServiceArgument)) {
             throw new Error('Wrong parameter type at position: ' + (index));
         }
@@ -18,21 +19,19 @@ var ServiceArgumentCollection = function ServiceArgumentCollection(serviceArgume
 };
 
 /**
- * @return {Array.<ServiceArgument>}
+ * @return {Array<ServiceArgument>}
  */
 ServiceArgumentCollection.prototype.getArguments = function () {
-    return this.serviceArgumentList.toArray();
+    return this.serviceArguments;
 };
 
 /**
- * @return {Array.<ServiceArgument>}
+ * @return {Array<ServiceArgument>}
  */
 ServiceArgumentCollection.prototype.getServiceArguments = function () {
-    var serviceReferenceArgumentList = this.serviceArgumentList.filter(function (argument) {
+    return filter(this.serviceArguments, function (argument) {
         return argument.isServiceReference();
     });
-
-    return serviceReferenceArgumentList.toArray();
 };
 
 module.exports = ServiceArgumentCollection;

--- a/src/ServiceDefinitionCollection.js
+++ b/src/ServiceDefinitionCollection.js
@@ -1,16 +1,17 @@
 'use strict';
 
-var List = require('immutable').List;
+var each = require('lodash/collection/each');
+var find = require('lodash/collection/find');
 var ServiceDefinition = require('./ServiceDefinition');
 
 /**
- * @param {Array.<ServiceDefinition>} serviceDefinitions
+ * @param {Array<ServiceDefinition>} serviceDefinitions
  * @constructor
  */
 var ServiceDefinitionCollection = function ServiceDefinitionCollection(serviceDefinitions) {
-    this.serviceDefinitionList = new List(serviceDefinitions || []);
+    this.serviceDefinitions = serviceDefinitions || [];
 
-    this.serviceDefinitionList.map(function (definition, index) {
+    each(this.serviceDefinitions, function (definition, index) {
         if (!(definition instanceof ServiceDefinition)) {
             throw new Error('Wrong parameter type at position: ' + index);
         }
@@ -22,7 +23,7 @@ var ServiceDefinitionCollection = function ServiceDefinitionCollection(serviceDe
  * @return {ServiceDefinition|undefined}
  */
 ServiceDefinitionCollection.prototype.getServiceDefinition = function (name) {
-    return this.serviceDefinitionList.find(function (serviceDefinition) {
+    return find(this.serviceDefinitions, function (serviceDefinition) {
         return (serviceDefinition.getName() === name);
     });
 };
@@ -39,7 +40,7 @@ ServiceDefinitionCollection.prototype.hasServiceDefinition = function (name) {
  * @param {Function} cb
  */
 ServiceDefinitionCollection.prototype.forEach = function (cb) {
-    this.serviceDefinitionList.forEach(function (serviceDefinition) {
+    each(this.serviceDefinitions, function (serviceDefinition) {
         return cb(serviceDefinition);
     });
 };

--- a/tests/units/ParameterCollectionSpec.js
+++ b/tests/units/ParameterCollectionSpec.js
@@ -18,12 +18,6 @@ describe('ParameterCollection', function () {
         }).not.to.throw();
     });
 
-    it('should only accept Array', function () {
-        expect(function () {
-            new ParameterCollection({});
-        }).to.throw();
-    });
-
     it('should only accept Parameter inside the Array', function () {
         var fooParameter = sinon.createStubInstance(Parameter);
         var barParameter = sinon.createStubInstance(Parameter);


### PR DESCRIPTION
We only use ImmutableJS has an helper to iterate over data (like [here](https://github.com/rezzza/skippy/blob/b2b03254e13e5eed90e2b4790d80d9c5e2fe6ffc/src/ParameterCollection.js#L11-L17)). We need to prefer the use of `lodash` (simpler dependency, probably faster).