### PR TITLE
Change the instanciation method to be compatible with the native node class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ node_js:
     - "4.4"
 
 script:
-    - npm test
-    - npm run lint
-    - npm run coverage && npm run coverage-upload
+    - yarn run test
+    - yarn run lint
+    - yarn run coverage && yarn run coverage-upload
 
 notifications:
     email:

--- a/src/ObjectHelper.js
+++ b/src/ObjectHelper.js
@@ -19,12 +19,9 @@ ObjectHelper.clone = function clone(object) {
  * @return {*}
  */
 ObjectHelper.createInstance = function createInstance(constructor, newInstanceArguments) {
-    // From: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply#Using_apply_to_chain_constructors
-    var proxyConstructor = Object.create(constructor.prototype);
-
-    constructor.apply(proxyConstructor, newInstanceArguments);
-
-    return proxyConstructor;
+    // This solution come from babel.
+    // Try it here: http://babeljs.io/repl/#?babili=false&evaluate=true&lineWrap=false&presets=es2015&code=%0Aclass%20Bar%20%7B%0A%7D%0A%0Anew%20Bar(...%5B1%2C%202%5D)%3B
+    return new (Function.prototype.bind.apply(constructor, [null].concat(newInstanceArguments)))();
 };
 
 module.exports = ObjectHelper;


### PR DESCRIPTION
This PR solve this issue:

```
 TypeError: Class constructor HttpClient cannot be invoked without 'new'
         at Object.createInstance (/home/node/node_modules/skippy/src/ObjectHelper.js:25:17)
         at ServiceDefinition.createInstance (/home/node/node_modules/skippy/src/ServiceDefinition.js:47:25)
         at Container.getService (/home/node/node_modules/skippy/src/Container.js:64:45)
         at Container.getService (/home/node/app/src/Bootstrap/Container.js:32:28)
         at /home/node/app/src/Testing/IntegrationTestWorld.js:50:79
         at undefined.next (native)
         at step (/home/node/app/src/Testing/IntegrationTestWorld.js:37:191)
         at /home/node/app/src/Testing/IntegrationTestWorld.js:37:437
         at /home/node/app/src/Testing/IntegrationTestWorld.js:37:99
```


When will convert this project in ES6 this will be more easy to read.